### PR TITLE
return compliance statement from pre_sub fn #51

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: srr
 Title: 'rOpenSci' Review Roclets
-Version: 0.1.4.002
+Version: 0.1.4.003
 Authors@R: 
     person("Mark", "Padgham", , "mark@ropensci.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: srr
 Title: 'rOpenSci' Review Roclets
-Version: 0.1.4.003
+Version: 0.1.4.004
 Authors@R: 
     person("Mark", "Padgham", , "mark@ropensci.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265"))

--- a/R/pre-submit.R
+++ b/R/pre-submit.R
@@ -74,6 +74,7 @@ srr_stats_pre_submit <- function (path = ".", quiet = FALSE) {
         for (s in compliance_statement) {
             cli::cli_alert_warning (s)
         }
+        msg <- c (msg, compliance_statement)
     }
 
     invisible (msg)

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/srr",
   "issueTracker": "https://github.com/ropensci-review-tools/srr/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.1.4.002",
+  "version": "0.1.4.003",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/srr",
   "issueTracker": "https://github.com/ropensci-review-tools/srr/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.1.4.003",
+  "version": "0.1.4.004",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -12,24 +12,34 @@ test_that ("release", {
     file.remove (file.path (d, "README.Rmd"))
 
     x <- utils::capture.output (
-        srr_stats_pre_submit (d),
+        rep <- srr_stats_pre_submit (d),
         type = "message"
     )
     expect_true (length (x) > 100) # > 100 standards are missing
 
-    errs <- grep ("^\\!", x)
-    expect_length (errs, 4L)
+    errs_output <- grep ("^\\!", x)
+    expect_length (errs_output, 4L)
+    # Report has error text only, no symbols or exclamations:
+    errs_rep <- grep ("^\\!", rep)
+    expect_length (errs_rep, 0L)
 
     msg <- "package still has TODO standards and can not be submitted"
     expect_length (grep (msg, x), 1L)
+    expect_length (grep (msg, rep), 1L)
     msg <- "the following standards (.*) are missing from your code"
     expect_length (grep (msg, x), 1L)
+    expect_length (grep (msg, rep), 1L)
 
     msg <- "must comply with at least 50% of all standards"
     expect_length (grep (msg, x), 1L)
+    expect_length (grep (msg, rep), 1L)
     msg <- "must comply with at least 50% of category-specific standards"
     expect_length (grep (msg, x), 1L)
+    expect_length (grep (msg, rep), 1L)
 
-    missing_stds <- grep ("^[0-9]+", x)
-    expect_true (length (missing_stds) > 100L)
+    missing_stds_output <- grep ("^[0-9]+", x)
+    missing_stds_rep <- grep ("[A-Z][0-9]+\\.[0-9]", rep, value = T)
+    expect_true (length (missing_stds_output) > 100L)
+    expect_true (length (missing_stds_rep) > 100L)
+    expect_equal (length (missing_stds_output), length (missing_stds_rep))
 })


### PR DESCRIPTION
Former version just printed it, but didn't add to return value